### PR TITLE
Initialize boto3 clients per region in the constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### (2019-06-12)
+- Fixed boto3 multithreading use
+
 ### 1.1.0 (2019-06-11)
 - Release 1.1.0 with threads support to query all region in parallel
 

--- a/prometheus_aws_guardduty_exporter/collector.py
+++ b/prometheus_aws_guardduty_exporter/collector.py
@@ -11,7 +11,6 @@ class GuardDutyMetricsCollector():
         self.regions = regions
         self.pool = Pool(len(self.regions))
         self.scrapeErrors = {region: 0 for region in regions}
-        self.botoClients = {}
 
     def collect(self):
         # Init metrics

--- a/prometheus_aws_guardduty_exporter/collector.py
+++ b/prometheus_aws_guardduty_exporter/collector.py
@@ -9,12 +9,9 @@ from prometheus_client.core import GaugeMetricFamily, CounterMetricFamily
 class GuardDutyMetricsCollector():
     def __init__(self, regions: List[str]):
         self.regions = regions
-        self.botoConfig = botocore.client.Config(connect_timeout=2, read_timeout=10, retries={"max_attempts": 2})
         self.pool = Pool(len(self.regions))
         self.scrapeErrors = {region: 0 for region in regions}
         self.botoClients = {}
-        for region in self.regions:
-            self.botoClients[region] = boto3.client("guardduty", config=self.botoConfig, region_name=region)
 
     def collect(self):
         # Init metrics
@@ -42,7 +39,8 @@ class GuardDutyMetricsCollector():
         return [currentFindingsMetric, scrapeErrorsMetric]
 
     def _collectMetricsByRegion(self, region):
-        client = self.botoClients[region]
+        botoConfig = botocore.client.Config(connect_timeout=2, read_timeout=10, retries={"max_attempts": 2})
+        client = boto3.client("guardduty", config=botoConfig, region_name=region)
         regionStats = {"low": 0, "medium": 0, "high": 0}
 
         try:

--- a/prometheus_aws_guardduty_exporter/collector.py
+++ b/prometheus_aws_guardduty_exporter/collector.py
@@ -12,6 +12,9 @@ class GuardDutyMetricsCollector():
         self.botoConfig = botocore.client.Config(connect_timeout=2, read_timeout=10, retries={"max_attempts": 2})
         self.pool = Pool(len(self.regions))
         self.scrapeErrors = {region: 0 for region in regions}
+        self.botoClients = {}
+        for region in self.regions:
+            self.botoClients[region] = boto3.client("guardduty", config=self.botoConfig, region_name=region)
 
     def collect(self):
         # Init metrics
@@ -39,7 +42,7 @@ class GuardDutyMetricsCollector():
         return [currentFindingsMetric, scrapeErrorsMetric]
 
     def _collectMetricsByRegion(self, region):
-        client = boto3.client("guardduty", config=self.botoConfig, region_name=region)
+        client = self.botoClients[region]
         regionStats = {"low": 0, "medium": 0, "high": 0}
 
         try:


### PR DESCRIPTION
Boto3 is not multithread safe and the recommendation is to create boto3 clients in each thread. I took the approach of creating them in the constructor, one client per region.