### PR TITLE
Upgrade Python to 3.11 and dependencies to latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.0.0 (2023-09-25)
+- Upgrade to Python 3.11
+- Upgrade dependencies
+
 ### 1.1.2 (2019-06-12)
 - Release 1.1.2 that fixes multithreading sessions with boto3 client
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.9
+FROM alpine:3.18
 
-RUN apk add --update --no-cache python3~=3.6 && \
-    python3 -m pip install prometheus-aws-guardduty-exporter==1.1.2 --no-cache-dir
+RUN apk add --update --no-cache python3~=3.11 && \
+    python3 -m pip install prometheus-aws-guardduty-exporter==2.0.0 --no-cache-dir
 
 # Run as non-root
 RUN adduser app -S -u 1000

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,8 +1,10 @@
-FROM alpine:3.9
+FROM alpine:3.18
 
 # Installing required packages
 RUN apk add --update --no-cache \
-    python3~=3.6
+    gcc libc-dev libffi-dev \
+    python3~=3.11 python3-dev~=3.11 \
+    py3-pip
 
 # Install app code
 RUN mkdir /app

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2019 - Spreaker, Inc.
+Copyright 2023 - Spreaker, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,5 @@ services:
     volumes:
       - .:/app:delegated
       - ~/.aws:/home/app/.aws:ro
+    environment:
+      - AWS_DEFAULT_REGION=us-east-1

--- a/prometheus_aws_guardduty_exporter/cli.py
+++ b/prometheus_aws_guardduty_exporter/cli.py
@@ -26,7 +26,7 @@ def main(args):
 
     # Init logger
     logHandler = logging.StreamHandler()
-    formatter = jsonlogger.JsonFormatter("(asctime) (levelname) (message)", datefmt="%Y-%m-%d %H:%M:%S")
+    formatter = jsonlogger.JsonFormatter("%(asctime)s %(levelname)s %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
     logHandler.setFormatter(formatter)
 
     logger = logging.getLogger()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import sys
 from setuptools import setup
 
 # Version
-version = "1.1.2"
+version = "2.0.0"
 
 # Requires Python 3
 if sys.version_info.major < 3:
@@ -19,18 +19,18 @@ setup(
   description                   = 'Prometheus exporter for AWS GuardDuty',
   long_description              = long_description,
   long_description_content_type = 'text/markdown',
-  author                        = 'Marco Pracucci',
-  author_email                  = 'marco@pracucci.com',
+  author                        = 'Spreaker',
+  author_email                  = 'dev@spreaker.com',
   url                           = 'https://github.com/spreaker/prometheus-aws-guardduty-exporter',
   download_url                  = f'https://github.com/spreaker/prometheus-aws-guardduty-exporter/archive/{version}.tar.gz',
   keywords                      = ['prometheus', 'aws', 'guardduty'],
   classifiers                   = [],
-  python_requires               = ' >= 3',
-  install_requires              = ["boto3==1.9.148", "python-json-logger==0.1.11", "prometheus_client==0.6.0"],
+  python_requires               = ' >= 3.11',
+  install_requires              = ["boto3==1.28.53", "python-json-logger==2.0.7", "prometheus_client==0.17.1"],
   extras_require = {
     'dev': [
-      'flake8==3.7.7',
-      'twine==1.13.0'
+      'flake8==6.1.0',
+      'twine==4.0.2'
     ]
   },
   entry_points = {


### PR DESCRIPTION
This PR upgrades Python to version 3.11 and every dependency to use their latest version. 

This comes with a major version bump to 2.0.0